### PR TITLE
Include Procfile step in tutorial

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -124,6 +124,14 @@ Create a `.env` file with the API token from above and make sure to add it to `.
 SLACK_API_TOKEN=...
 ```
 
+### Procfile
+
+Create a `Procfile` which `foreman` will use when you run the `foreman start` command below.
+
+```
+web: bundle exec puma -p $PORT
+```
+
 ### Run the Bot
 
 Run `foreman start`. Your bot should be running.


### PR DESCRIPTION
Hi,  I ran through the tutorial and without this step, `foreman start` produces: "ERROR: Procfile does not exist."

Thanks for your work on slack-ruby-bot!