### PR TITLE
Initialize the App class .instance is called on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.5.1 (Next)
 
+* [#33](https://github.com/dblock/slack-ruby-bot/pull/33): `SlackRubyBot::App.instance` now creates an instance of the class on which it is called - [@dmvt](https://github.com/dmvt).
 * Your contribution here.
 
 ### 0.5.0 (12/7/2015)
@@ -62,4 +63,3 @@
 ### 0.1.0 (6/2/2015)
 
 * Initial public release - [@dblock](https://github.com/dblock).
-

--- a/lib/slack-ruby-bot/app.rb
+++ b/lib/slack-ruby-bot/app.rb
@@ -15,7 +15,7 @@ module SlackRubyBot
     end
 
     def self.instance
-      @instance ||= SlackRubyBot::App.new
+      @instance ||= new
     end
 
     private

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -5,4 +5,11 @@ describe SlackRubyBot::App do
     SlackRubyBot::App.new
   end
   it_behaves_like 'a slack ruby bot'
+
+  describe '.instance' do
+    it 'creates an instance of the App subclass' do
+      klass = Class.new(SlackRubyBot::App)
+      expect(klass.instance.class).to be klass
+    end
+  end
 end


### PR DESCRIPTION
Initializes the subclass (for instance `PongBot::App` in the first `README` example) instead of `SlackRubyBot::App` specifically. This allows for easier behavior modification through custom `Hooks` and direct method overriding.