### PR TITLE
Fix #76: remove infinite restart when app disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#69](https://github.com/dblock/slack-ruby-bot/pull/69): Ability to add help info to bot and commands - [@accessd](https://github.com/accessd).
 * [#75](https://github.com/dblock/slack-ruby-bot/issues/75): Guarantee order of command evaluation - [@dblock](https://github.com/dblock).
+* [#76](https://github.com/dblock/slack-ruby-bot/issues/76): Infinity error when app disabled - [@slayershadow](https://github.com/SlayerShadow).
 * Your contribution here.
 
 ### 0.8.0 (5/5/2016)

--- a/lib/slack-ruby-bot/server.rb
+++ b/lib/slack-ruby-bot/server.rb
@@ -51,10 +51,15 @@ module SlackRubyBot
     def restart!(wait = 1)
       @async ? start_async : start!
     rescue StandardError => e
-      sleep wait
-      logger.error "#{e.message}, reconnecting in #{wait} second(s)."
-      logger.debug e
-      restart! [wait * 2, 60].min
+      case e.message
+        when 'account_inactive', 'invalid_auth'
+          logger.error "#{token}: #{e.message}, team will be deactivated."
+        else
+          sleep wait
+          logger.error "#{e.message}, reconnecting in #{wait} second(s)."
+          logger.debug e
+          restart! [wait * 2, 60].min
+      end
     end
 
     private

--- a/lib/slack-ruby-bot/server.rb
+++ b/lib/slack-ruby-bot/server.rb
@@ -52,14 +52,14 @@ module SlackRubyBot
       @async ? start_async : start!
     rescue StandardError => e
       case e.message
-        when 'account_inactive', 'invalid_auth'
-          logger.error "#{token}: #{e.message}, team will be deactivated."
-          @stopping = true
-        else
-          sleep wait
-          logger.error "#{e.message}, reconnecting in #{wait} second(s)."
-          logger.debug e
-          restart! [wait * 2, 60].min
+      when 'account_inactive', 'invalid_auth'
+        logger.error "#{token}: #{e.message}, team will be deactivated."
+        @stopping = true
+      else
+        sleep wait
+        logger.error "#{e.message}, reconnecting in #{wait} second(s)."
+        logger.debug e
+        restart! [wait * 2, 60].min
       end
     end
 

--- a/lib/slack-ruby-bot/server.rb
+++ b/lib/slack-ruby-bot/server.rb
@@ -54,6 +54,7 @@ module SlackRubyBot
       case e.message
         when 'account_inactive', 'invalid_auth'
           logger.error "#{token}: #{e.message}, team will be deactivated."
+          @stopping = true
         else
           sleep wait
           logger.error "#{e.message}, reconnecting in #{wait} second(s)."

--- a/spec/slack-ruby-bot/server_spec.rb
+++ b/spec/slack-ruby-bot/server_spec.rb
@@ -88,4 +88,21 @@ describe SlackRubyBot::Server do
       end
     end
   end
+  context '#restart!' do
+    subject do
+      SlackRubyBot::Server.new(token: 'token')
+    end
+    it 'reloads server after disconnection' do
+      expect(subject).to receive(:restart!)
+      subject.send(:client).send(:callbacks)['close'].first.call
+      expect(subject.instance_variable_get :@stopping).to be_falsy
+    end
+    it 'does not reload server for inactive account' do
+      stopping = -> { subject.instance_variable_get :@stopping }
+      allow(subject).to receive(:start!){ raise StandardError, 'account_inactive' }
+      expect(stopping.call).to be_falsy
+      subject.restart!
+      expect(stopping.call).to be true
+    end
+  end
 end

--- a/spec/slack-ruby-bot/server_spec.rb
+++ b/spec/slack-ruby-bot/server_spec.rb
@@ -95,11 +95,11 @@ describe SlackRubyBot::Server do
     it 'reloads server after disconnection' do
       expect(subject).to receive(:restart!)
       subject.send(:client).send(:callbacks)['close'].first.call
-      expect(subject.instance_variable_get :@stopping).to be_falsy
+      expect(subject.instance_variable_get(:@stopping)).to be_falsy
     end
     it 'does not reload server for inactive account' do
       stopping = -> { subject.instance_variable_get :@stopping }
-      allow(subject).to receive(:start!){ raise StandardError, 'account_inactive' }
+      allow(subject).to receive(:start!) { raise StandardError, 'account_inactive' }
       expect(stopping.call).to be_falsy
       subject.restart!
       expect(stopping.call).to be true


### PR DESCRIPTION
Added error checking for `restart!` method on `lib/slack-ruby-bot/server.rb`.