### PR TITLE
remove bundler dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#69](https://github.com/dblock/slack-ruby-bot/pull/69): Ability to add help info to bot and commands - [@accessd](https://github.com/accessd).
 * [#75](https://github.com/dblock/slack-ruby-bot/issues/75): Guarantee order of command evaluation - [@dblock](https://github.com/dblock).
 * [#76](https://github.com/dblock/slack-ruby-bot/issues/76): Infinity error when app disabled - [@slayershadow](https://github.com/SlayerShadow).
+* [#81](https://github.com/dblock/slack-ruby-bot/pull/81): Remove bundler dependency - [@derekddecker](https://github.com/derekddecker).
 * Your contribution here.
 
 ### 0.8.0 (5/5/2016)

--- a/lib/config/application.rb
+++ b/lib/config/application.rb
@@ -3,8 +3,6 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'boot'
 
-Bundler.require :default, ENV['RACK_ENV']
-
 Dir[File.expand_path('../../initializers', __FILE__) + '/**/*.rb'].each do |file|
   require file
 end

--- a/lib/config/boot.rb
+++ b/lib/config/boot.rb
@@ -1,5 +1,4 @@
 require 'rubygems'
-require 'bundler/setup'
 require 'logger'
 require 'active_support'
 require 'active_support/core_ext'

--- a/spec/slack-ruby-bot/app_spec.rb
+++ b/spec/slack-ruby-bot/app_spec.rb
@@ -12,4 +12,11 @@ describe SlackRubyBot::App do
       expect(klass.instance.class).to be klass
     end
   end
+
+  describe 'executable' do
+    it 'can be required as a dependency' do
+      response = system("ruby -e \"Bundler = nil ; require 'slack-ruby-bot'\"")
+      expect(response).to be true
+    end
+  end
 end


### PR DESCRIPTION
Creating gem executables with slack-ruby-bot as a dependency results in a 'Bundler::GemfileNotFound' exception out of config/application.rb where Bundler is a dependency:

```sh
dddecker@localhost:~$ runbot
/Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/bundler-1.12.5/lib/bundler.rb:170:in `rescue in root': Could not locate Gemfile or .bundle/ directory (Bundler::GemfileNotFound)
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/bundler-1.12.5/lib/bundler.rb:166:in `root'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/bundler-1.12.5/lib/bundler.rb:74:in `bundle_path'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/bundler-1.12.5/lib/bundler.rb:414:in `configure_gem_home_and_path'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/bundler-1.12.5/lib/bundler.rb:60:in `configure'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/bundler-1.12.5/lib/bundler.rb:121:in `definition'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/bundler-1.12.5/lib/bundler.rb:91:in `setup'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/bundler-1.12.5/lib/bundler.rb:102:in `require'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/slack-ruby-bot-0.8.0/lib/config/application.rb:6:in `<top (required)>'
from /Users/dddecker/.rvm/rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:120:in `require'
from /Users/dddecker/.rvm/rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:120:in `require'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/slack-ruby-bot-0.8.0/lib/config/environment.rb:3:in `<top (required)>'
from /Users/dddecker/.rvm/rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:120:in `require'
from /Users/dddecker/.rvm/rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:120:in `require'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/slack-ruby-bot-0.8.0/lib/slack-ruby-bot.rb:1:in `<top (required)>'
from /Users/dddecker/.rvm/rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:68:in `require'
from /Users/dddecker/.rvm/rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:68:in `require'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/application-0.1.2/lib/application.rb:1:in `<top (required)>'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/application-0.1.2/bin/application:23:in `require_relative'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/gems/application-0.1.2/bin/application:23:in `<top (required)>'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/bin/application:22:in `load'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/bin/application:22:in `<main>'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/bin/ruby_executable_hooks:15:in `eval'
from /Users/dddecker/.rvm/gems/ruby-2.3.1@application/bin/ruby_executable_hooks:15:in `<main>'
```

Removing it fixes the problem.